### PR TITLE
Corrigindo o erro Parse Error: syntax error, unexpected '}' no SoapImpl.php

### DIFF
--- a/src/Egoi/Api/SoapImpl.php
+++ b/src/Egoi/Api/SoapImpl.php
@@ -43,7 +43,6 @@ class SoapImpl extends Api {
         $fn = __FUNCTION__;
         return $this->rpc->$fn($map);
     }
-    }
 
 
     function attachTag($map) {


### PR DESCRIPTION
Na linha 45 do arquivo SoapImpl.php continha um '}' a mais. Isso estava impedindo o uso do mesmo.
Aguardo aprovação para continuar minha integração utilizando o código de vocês.